### PR TITLE
Update README with pnpm install instructions

### DIFF
--- a/crux-agent/README.md
+++ b/crux-agent/README.md
@@ -169,6 +169,8 @@ python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 cd crux-mvp
 
 # Install dependencies
+# Install pnpm if not already installed
+npm install -g pnpm
 pnpm install
 # Or use npm: npm install
 


### PR DESCRIPTION
## Summary
- update frontend quickstart instructions

## Testing
- `pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688548e69c8c832dbef5a6effae31e60