### PR TITLE
Fix README example path

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ pip install -r requirements.txt
 export OPENAI_API_KEY="your-key-here"
 
 # Run basic example
-python -m self-evolve.exampels.example_usage.py
+python -m self-evolve.examples.example_usage.py
 
 # Run enhanced Professor-Graduate architecture
 python -m self-evolve.examples.professor_graduate_example


### PR DESCRIPTION
## Summary
- fix example path in README

## Testing
- `pytest -q` *(fails: cannot import name 'get_current_user_from_api_key')*

------
https://chatgpt.com/codex/tasks/task_e_688548e94394832d8112163023d1b902